### PR TITLE
Fix port switcheroo and clarify exercise 2.1 requirement.

### DIFF
--- a/exercises.md
+++ b/exercises.md
@@ -20,9 +20,9 @@ Please note that at the moment of writing this (26.10) not all exercises have be
 
 Beta deadlines, please not that these are not "hard deadlines" as there might be major changes:
 
-Deadline for part 1 is 26.11. 
-Deadline for part 2 is 10.12. 
-Deadline for part 3 is 22.12.
+Deadline for part 1 is 26.11.  
+Deadline for part 2 is 10.12.  
+Deadline for part 3 is 22.12.  
 
 ## Part 1
 
@@ -103,7 +103,7 @@ Explain what you created and publish it to Docker Hub.
 
 **2.1**
 
-Configuring 1.3 to 1.5 in docker-compose.
+Configuring 1.4 to 1.5 in docker-compose.
 
 Since we already created working Dockerfiles for both frontend and backend we can go step further and simplify the usage into one docker-compose.yml.
 

--- a/part1.md
+++ b/part1.md
@@ -568,16 +568,16 @@ To expose a port, add line `EXPOSE <port>` in your Dockerfile
 
 To publish a port, run the container with `-p <host-port>:<container-port>`
 
-For example: A certain application uses port 1234 to accept udp connections.
+For example: A certain application uses port 4567 to accept udp connections.
 
-`EXPOSE 1234` in the Dockerfile will allow container created from the image to accept connections.
+`EXPOSE 4567` in the Dockerfile will allow container created from the image to accept connections.
 Lets say that the image name is "app-in-port"
 
 - `docker run -p 1234:4567 app-in-port`
 
-Now you could make connection to host port 4567 and it will be mapped to the application port.
+Now you could make connection to host port 1234 (for example http://localhost:1234) and it will be mapped to the application port.
 
-You can also limit connections to certain protocol only, in this case udp by adding the protocol at the end: `EXPOSE 1234/udp` and `-p 1234:4567/udp` respectively.
+You can also limit connections to certain protocol only, in this case udp by adding the protocol at the end: `EXPOSE 4567/udp` and `-p 1234:4567/udp` respectively.
 
 Do exercises 1.4, 1.5 and 1.6
 


### PR DESCRIPTION
- Added spaces to the EOF of beta deadlines to have each on own line.
- Removed 1.3 from the exercise 2.1 requirements for docker-compose, as 1.3 can be done without Dockerfile, and is not part of front-back-exercise.