### PR TITLE
Fix docker inspect command

### DIFF
--- a/part2.md
+++ b/part2.md
@@ -383,7 +383,7 @@ $ docker volume ls
 DRIVER              VOLUME NAME
 local               redmine_database
 
-$ ongoing docker inspect db_redmine | grep -A 5 Mounts
+$ docker inspect db_redmine | grep -A 5 Mounts
 "Mounts": [
     {
         "Type": "volume",


### PR DESCRIPTION
I made this pull-request, as the original command with the word `ongoing` does not work, and the intention seems to be to run `docker inspect` like previously. 