### PR TITLE
Added apt-get update before installing curl and python

### DIFF
--- a/pages/part1/part1.md
+++ b/pages/part1/part1.md
@@ -546,7 +546,7 @@ So now when we know what do, let's add these to the bottom of our `Dockerfile` -
 
 ```dockerfile
 ... 
-RUN apt-get install -y curl python 
+RUN apt-get update && apt-get install -y curl python 
 RUN curl -L https://yt-dl.org/downloads/latest/youtube-dl -o /usr/local/bin/youtube-dl 
 RUN chmod a+x /usr/local/bin/youtube-dl 
 ENV LC_ALL=C.UTF-8 


### PR DESCRIPTION
I noticed there wasn't `apt-get update` before installing curl and python, which might lead into cache issues. Added `apt-get update &&` on the same line.