### PR TITLE
Fix link in exercise 2.5 by escaping the underscore

### DIFF
--- a/pages/part2/exercises/2_5.html
+++ b/pages/part2/exercises/2_5.html
@@ -9,7 +9,7 @@
   10 to 20 seconds to get a response.
 
   Configure a redis container to cache information for the backend. Use the documentation if needed when configuring:
-  [https://hub.docker.com/_/redis/](https://hub.docker.com/_/redis/)
+  [https://hub.docker.com/\_/redis/](https://hub.docker.com/\_/redis/)
 
   The backend [README](https://github.com/docker-hy/backend-example-docker) should have all the information needed to
   connect.


### PR DESCRIPTION
Link to redis page in docker hub contained underscore, and it wasn't escaped so it broke the link. I added escapes.