### PR TITLE
Update 2_6.html

### DIFF
--- a/pages/part2/exercises/2_6.html
+++ b/pages/part2/exercises/2_6.html
@@ -6,7 +6,7 @@
 
   Lets use a postgres database to save messages. We won't need to configure a volume since the official postgres image
   sets a default volume for us. Lets use the postgres image documentation to our advantage when configuring:
-  [https://hub.docker.com/_/postgres/](https://hub.docker.com/\_/postgres/). Especially part Environment Variables is of
+  [https://hub.docker.com/_/postgres/](https://hub.docker.com/_/postgres/). Especially part Environment Variables is of
   interest.
 
   The backend [README](https://github.com/docker-hy/backend-example-docker) should have all the information needed to

--- a/pages/part2/exercises/2_6.html
+++ b/pages/part2/exercises/2_6.html
@@ -6,7 +6,7 @@
 
   Lets use a postgres database to save messages. We won't need to configure a volume since the official postgres image
   sets a default volume for us. Lets use the postgres image documentation to our advantage when configuring:
-  [https://hub.docker.com/\_/postgres/](https://hub.docker.com/\_/postgres/). Especially part Environment Variables is of
+  [https://hub.docker.com/_/postgres/](https://hub.docker.com/\_/postgres/). Especially part Environment Variables is of
   interest.
 
   The backend [README](https://github.com/docker-hy/backend-example-docker) should have all the information needed to


### PR DESCRIPTION
Tiny `<a href=https://hub.docker.com/\_/postgres/` instead of `https://hub.docker.com/_/postgres/` for exercise `2.6`, docker hub kept 404ing me when clicking on link as a result.