### PR TITLE
Fixed typo in ex1.10

### DIFF
--- a/pages/part1/exercises/1_10.html
+++ b/pages/part1/exercises/1_10.html
@@ -22,6 +22,6 @@
   > TIP: Note that the app starts to accept connections when "Accepting connections at http://localhost:5000" has been
   printed to the screen, this takes a few seconds
 
-  > TIP: You do not have to install anything new outside containers.
+  > TIP: You do not have to install anything new aside from containers.
 
 </div>


### PR DESCRIPTION
`outside` -> `aside from`