### PR TITLE
Fixed link in ex2.6

### DIFF
--- a/pages/part2/exercises/2_6.html
+++ b/pages/part2/exercises/2_6.html
@@ -6,7 +6,7 @@
 
   Lets use a postgres database to save messages. We won't need to configure a volume since the official postgres image
   sets a default volume for us. Lets use the postgres image documentation to our advantage when configuring:
-  [https://hub.docker.com/_/postgres/](https://hub.docker.com/_/postgres/). Especially part Environment Variables is of
+  [https://hub.docker.com/\_/postgres/](https://hub.docker.com/\_/postgres/). Especially part Environment Variables is of
   interest.
 
   The backend [README](https://github.com/docker-hy/backend-example-docker) should have all the information needed to


### PR DESCRIPTION
`[https://hub.docker.com/_/postgres/](https://hub.docker.com/_/postgres/)` is shown as
[https://hub.docker.com/ */postgres/](https://hub.docker.com/* /postgres/) instead of [https://hub.docker.com/\_/postgres/](https://hub.docker.com/\_/postgres/).

Fixed by escaping _ with \