### PR TITLE
--sig-proxy isn't any better, use `--no-stdin` instead.

### DIFF
--- a/pages/part1/part1.md
+++ b/pages/part1/part1.md
@@ -353,7 +353,7 @@ $ docker attach looper-it
   ^P^Qread escape sequence
 ```
 
-Note that hitting `^C` would still kill (and remove due to `--rm`) the process because the `docker attach` command did not include `--sig-proxy=false` 
+Instead if had used ctrl+c it would have send a kill signal followed by removing the container as we specified --rm in `docker run` command.
 
 {% include_relative exercises/1_4.html %}
 {% include_relative exercises/1_5.html %}

--- a/pages/part1/part1.md
+++ b/pages/part1/part1.md
@@ -297,14 +297,14 @@ $ docker attach looper
 
 Now you have process logs (STDOUT) running in two terminals. Now press control+c in the attached window. The container is stopped because the process is no longer running.
 
-If we want to attach to a container while making sure we don't close it from the other terminal we can disable signal proxying. Let's start the stopped container with `docker start looper` and attach to it with `--sig-proxy=false`. 
+If we want to attach to a container while making sure we don't close it from the other terminal we can specify to not attach STDIN with `--no-stdin` option. Let's start the stopped container with `docker start looper` and attach to it with `--no-stdin`. 
 
 Then try control+c.
 
 ```console
 $ docker start looper 
 
-$ docker attach --sig-proxy=false looper 
+$ docker attach --no-stdin looper 
   Mon Jan 15 19:27:54 UTC 2018 
   Mon Jan 15 19:27:55 UTC 2018 
   ^C 


### PR DESCRIPTION
### `--sig-proxy` 's default action(i.e, ctrl+c kills sends sigterm signal) is not followed if the process ID is 1 (as we do have in our case, see img below).

#### OFFICIAL DOCS

![](https://i.imgur.com/FJpaI2B.png) [src in docs](https://docs.docker.com/engine/reference/commandline/attach/#extended-description)


#### Running ps aux in our container -> ![](https://i.imgur.com/SMK8cbw.png)

command used to start container -  `docker run -itd --name looper ubuntu:16.04 sh -c 'while true; do date; sleep 1; done'`



I would request you try `--no-stdin` behaviour as it simply doesn't work for me.  But `--no-stdin` works great as expected.
I am using windows 8.1, with Docker version: 19.03.1, build 74b1e89e8a, and tried and tested well(with bash, cmd, and powershell) on windows atleast(request you to see if there is this same bug is there with linux/macos too .?).

#### WORKS FINE!! (--no-stdin)
![](https://i.imgur.com/wEv86rT.png "WORKS FINE!!")

***

#### --sig-proxy doesn't work!
![](https://i.imgur.com/YWyceE8.png "--sig-proxy doesn't work!")

*Note here in `docker attach looper` command the container must have stopped but is not stopped. THAT MAKES --sig-proxy redundant.(ITS A BUG IN DOCKER DAEMON IMO). As i quote from OFFICIAL DOCS - 

> To stop a container, use CTRL-c. This key sequence sends SIGKILL to the container. If --sig-proxy is true (the default),CTRL-c sends a SIGINT to the container.

[SRC](https://docs.docker.com/engine/reference/commandline/attach/#extended-description).

Thanks.