### PR TITLE
Suggestion to use *wildcard* subdomain instead of whoami.colasloth.me which is *only* useful in development.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,5 +5,5 @@ workflows:
   deploy:
     jobs:
       - docker/publish:
-          image: jakousa/docker-hy
+          image: $DOCKER_LOGIN/$CIRCLE_PROJECT_REPONAME
           tag: 'latest'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3"
+services:
+  coursematerial:
+    image: sahilrajput03/docker-hy.github.io
+    ports:
+      - 4000:80
+    container_name: coursematerial
+  watchtower:
+    image: containrrr/watchtower
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    container_name: watchtower

--- a/pages/part0.md
+++ b/pages/part0.md
@@ -6,7 +6,7 @@ permalink: /part0/
 order: 0
 ---
 
-## General ##
+## General Guidelines ##
 
 This course is an introductory course to Docker and docker-compose. The course will also look into what different parts web services consist of, such as reverse proxies, databases, etc. Docker can not be installed on faculty computers, so students will need to use their computers to follow the examples outlined in this course material and to complete the exercises.
 

--- a/pages/part0.md
+++ b/pages/part0.md
@@ -6,7 +6,7 @@ permalink: /part0/
 order: 0
 ---
 
-## General Guidelines 123 ##
+## General ##
 
 This course is an introductory course to Docker and docker-compose. The course will also look into what different parts web services consist of, such as reverse proxies, databases, etc. Docker can not be installed on faculty computers, so students will need to use their computers to follow the examples outlined in this course material and to complete the exercises.
 

--- a/pages/part0.md
+++ b/pages/part0.md
@@ -6,7 +6,7 @@ permalink: /part0/
 order: 0
 ---
 
-## General Guidelines ##
+## General Guidelines 123 ##
 
 This course is an introductory course to Docker and docker-compose. The course will also look into what different parts web services consist of, such as reverse proxies, databases, etc. Docker can not be installed on faculty computers, so students will need to use their computers to follow the examples outlined in this course material and to complete the exercises.
 

--- a/pages/part2/part2.md
+++ b/pages/part2/part2.md
@@ -241,7 +241,9 @@ services:
     whoami: 
       image: jwilder/whoami 
       environment: 
-       - VIRTUAL_HOST=whoami.colasloth.com 
+       - VIRTUAL_HOST=whoami.*
+#COMMENT: Specifying VIRTUAL_HOST for this container binds `whoami` subdomain to it.
+
     proxy: 
       image: jwilder/nginx-proxy 
       volumes: 
@@ -260,6 +262,8 @@ $ curl whoami.colasloth.com
   I'm 740dc0de1954 
 ```
 
+Note: Instead of `colasloth.me`, you may replace it with `localtest.me`, `lvh.me` or `vcap.me` and it'll output same results as well.
+
 Let's add couple of more containers behind the same proxy. We can use the official `nginx` image to serve a simple static web page. We don't have to even build the container images, we can just mount the content to the image. Let's prepare some content for two services called "hello" and "world". 
 
 ```console
@@ -275,13 +279,13 @@ Then add these services to the `docker-compose.yml` file where you mount just th
       volumes: 
         - ./hello.html:/usr/share/nginx/html/index.html:ro 
       environment: 
-        - VIRTUAL_HOST=hello.colasloth.com 
+        - VIRTUAL_HOST=hello.*
     world: 
       image: nginx 
       volumes: 
         - ./world.html:/usr/share/nginx/html/index.html:ro 
       environment: 
-        - VIRTUAL_HOST=world.colasloth.com 
+        - VIRTUAL_HOST=world.*
 ``` 
 
 Now let's test: 


### PR DESCRIPTION
Using wildcard also is also good for production deployment, as it'll automatically map the sub domain to the desirable subdomain instead of manually adding our production DOMAIN to the VIRTUAL_HOST(list) environment variable for each container separately.