### PR TITLE
give external read access to the html files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,4 +21,4 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         push: true
-        tags: devopsdockeruh/coursepage:latest
+        tags: hajame/docker-hy-coursepage:latest

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 # [Course material](https://docker-hy.github.io)
 
 If you have any questions send email jami.kousa@helsinki.fi or send message in course telegram group.
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3"
+services:
+  coursematerial:
+    image: devopsdockeruh/coursepage
+    ports:
+      - 4000:80
+    container_name: coursematerial
+  watchtower:
+    image: containrrr/watchtower
+    environment:
+      -  WATCHTOWER_POLL_INTERVAL=60 # Poll every 60 seconds
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    container_name: watchtower

--- a/pages/part2/section-2.md
+++ b/pages/part2/section-2.md
@@ -184,11 +184,12 @@ $ curl whoami.colasloth.com
   I'm 740dc0de1954 
 ```
 
-Let's add couple of more containers behind the same proxy. We can use the official `nginx` image to serve a simple static web page. We don't have to even build the container images, we can just mount the content to the image. Let's prepare some content for two services called "hello" and "world". 
+Let's add couple of more containers behind the same proxy. We can use the official `nginx` image to serve a simple static web page. We don't have to even build the container images, we can just mount the content to the image. Let's prepare some html content for two services called "hello" and "world", and give other users read access to the files.
 
 ```console
 $ echo "hello" > hello.html
 $ echo "world" > world.html
+$ chmod go+r hello.html world.html
 ```
 
 Then add these services to the `docker-compose.yml` file where you mount just the content as `index.html` in the default nginx path: 


### PR DESCRIPTION
Without giving these read rights, nginx keeps responding with "403 Forbidden" for requests to 'hello.colasloth.com'.
Giving read access to other user groups solves the issue.