### PR TITLE
Fix two broken links in the Summary page of part 1 and part 2

### DIFF
--- a/data/part-1/section-7.md
+++ b/data/part-1/section-7.md
@@ -12,7 +12,7 @@ The process of dockerizing the applications meant a bit of configuration on our 
 
 Understanding the architecture and the technologies used is also part of making correct choices with the setup. This lead us to read the READMEs and documentation of the software involved in the setup, not just Docker. Fortunately in real life it's often us who are developing and creating the Dockerfile.
 
-The starting and stopping of containers is a bit annoying, not to mention running two applications at the same time. If only there was some way, a tool, to make it simpler... to [compose](/part2).
+The starting and stopping of containers is a bit annoying, not to mention running two applications at the same time. If only there was some way, a tool, to make it simpler... to [compose](/part-2).
 
 **Remember to mark your exercises into the submission application! Instructions on how and what to submit are on the getting started page.**
 

--- a/data/part-2/section-5.md
+++ b/data/part-2/section-5.md
@@ -8,7 +8,7 @@ Again we started from the ground up by learning how to translate non-compose set
 
 Now we've learned how to setup up vastly more complex applications with up to 5 different programs running at the same time and they only expose the used ports to the outside world (or even to our machine).
 
-Are we ready for production yet? Short answer: no. Long answer: depends on the situation. Good thing we have [part 3](/part3/)
+Are we ready for production yet? Short answer: no. Long answer: depends on the situation. Good thing we have [part 3](/part-3)
 
 **Remember to mark your exercises into the submission application! Instructions on how and what to submit are on the getting started page.**
 


### PR DESCRIPTION
I believe this should fix the broken compose-link. Currently the link gives a 404 error instead of showing the part 2 of the material.

// EDIT: I did the same fix for the link in part 2 summary which is supposed to lead to the part 3 but gives 404 error 