### PR TITLE
Add notice about deadline expiration

### DIFF
--- a/data/index.md
+++ b/data/index.md
@@ -7,6 +7,10 @@ banner: true
 sidebar_priority: 7000
 ---
 
+<text-box variant="hint" name="Notice">
+  <strong>The deadline for this course has passed.</strong> Submissions can no longer be made and you cannot receive credits or the certificate for this course.
+</text-box>
+
 This course is an introductory course to Docker and docker-compose. The course will also look into what different parts web services consist of, such as reverse proxies, databases, etc. Docker can not be installed on faculty computers, so students will need to use their computers to follow the examples outlined in this course material and to complete the exercises.
 
 ### Prerequisites


### PR DESCRIPTION
According to getting started (https://devopswithdocker.com/getting-started#deadline), the deadline for the course was on 22.5.2022.

A more explicit notice gives a heads-up for persons wanting to finish the course for credits that it is no longer an option.