### PR TITLE
Update section-6.md: fly.io seems to offer a free trial plan

### DIFF
--- a/docs/part-1/section-6.md
+++ b/docs/part-1/section-6.md
@@ -212,7 +212,7 @@ You can take any web-app, eg. an example or exercise from this part, your own ap
 
 There are plenty of alternatives, and most provide a free tier. Here are some alternatives that are quite simple to use:
 
-- [fly.io](https://fly.io) (easy to use but needs a credit card even in the free tier)
+- [fly.io](https://fly.io) (easy to use, setting up an app seems to put you a free trial plan)
 - [render.com](https://render.com) (bad documentation, you most likely need google)
 - [heroku.com](https://heroku.com) (has a free student plan)
 


### PR DESCRIPTION
It appears fly.io offers a free trial plan, even though this is not advertised on their site. The trial plan is what my account ended up showing after following a quick start guide to launching an app on fly.io. No payment details were asked at any point of the process.