### PR TITLE
Update GitHub actions to current versions

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -48,4 +48,4 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           push: true
-          tags: devopsdockeruh/coursepage:latest
+          tags: tuckerwarlock/devopswithdocker:latest

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -30,7 +30,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./build
-          cname: warlock-games.link
+          cname: devopswithdocker.com
 
   publish-docker-hub:
     name: Publish image to Docker Hub
@@ -48,4 +48,4 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           push: true
-          tags: tuckerwarlock/devopswithdocker:latest
+          tags: devopsdockeruh/coursepage:latest

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+warlock-games.link

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-warlock-games.link


### PR DESCRIPTION
## Purpose
This updates all the actions used to deploy the website and docker-hub image, this also removes the deprecation warnings for actions previously running on Node 16.

Deprecation warnings on original project

![image](https://github.com/user-attachments/assets/a7bbf6a2-c0b6-45ae-b3c1-b835ecf137f0)

Action runs with updated versions

https://github.com/TuckerWarlock/docker-hy.github.io/actions/runs/10334998879

![image](https://github.com/user-attachments/assets/5e9a0082-7cda-4b18-9a7e-9a022f578166)

https://github.com/TuckerWarlock/docker-hy.github.io/actions/runs/10334998890

![image](https://github.com/user-attachments/assets/f210b503-d88d-45d8-b759-63e1fb324d3b)
