### PR TITLE
Update section-4.md - Renamed as to AS on line 2 of the Dockerfile to fix the casing mismatch

### DIFF
--- a/docs/part-3/section-4.md
+++ b/docs/part-3/section-4.md
@@ -251,7 +251,7 @@ We could start thinking about optimizations at this point but instead, we're goi
 
 ```dockerfile
 # the  first stage needs to be given a name
-FROM ruby:3 as build-stage
+FROM ruby:3 AS build-stage
 WORKDIR /usr/app
 
 RUN gem install jekyll


### PR DESCRIPTION
**Description**:
This pull request addresses a warning found when building the Dockerfile on section "Multi-stage builds":

`1 warning found (use docker --debug to expand):  
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 2)  `

The issue occurred because the as keyword in the multi-stage build did not match the casing of the FROM keyword. This PR updates the as keyword to uppercase (AS) to align with the recommended casing convention.

**Changes Made**:
Renamed as to AS on line 2 of the Dockerfile to fix the casing mismatch.

